### PR TITLE
api-port: remove from generated config

### DIFF
--- a/lib/cmds/init.js
+++ b/lib/cmds/init.js
@@ -137,9 +137,7 @@ function initBaseGrenacheService (stype, sname, sport, sroot, conf, cb) {
   const grc = fs.readFileSync(gExampleFile, 'utf8')
   fs.writeFileSync(path.join(configRootTarget, 'facs', 'grc.config.json'), grc, 'utf8')
 
-  const sConfig = JSON.stringify({
-    'apiBfxPort': sport
-  }, null, '  ')
+  const sConfig = JSON.stringify({}, null, '  ')
   fs.writeFileSync(path.join(configRootTarget, configFileName), sConfig, 'utf8')
 
   const exampleJsFile = path.join(rootTemplates, 'example.js.tmpl.js')


### PR DESCRIPTION
 - port is passed via CLI only now