### PR TITLE
add example for `this.ctx` from worker.js

### DIFF
--- a/templates/api.wrk.js.tmpl.js
+++ b/templates/api.wrk.js.tmpl.js
@@ -26,6 +26,9 @@ class __WORKERCLASSNAME__ extends WrkApi {
 
   init () {
     super.init()
+
+    // contains all args passed to worker.js - also custom ones
+    // console.log(this.ctx)
   }
 }
 


### PR DESCRIPTION
this shows people starting with svc-js how they can access
custom arguments passed to the worker, without manual reparsing.